### PR TITLE
Allow override custom proxy params

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@ethersproject/abi':

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1225,6 +1225,9 @@ export function addHelpers(
         }
       }
 
+      checkABIConflict = options.proxy.checkABIConflict ?? checkABIConflict;
+      checkProxyAdmin = options.proxy.checkProxyAdmin ?? checkProxyAdmin;
+
       if (options.proxy.proxyContract) {
         if (typeof options.proxy.proxyContract === 'string') {
           try {
@@ -1305,7 +1308,7 @@ export function addHelpers(
     );
     // ensure no clash
     const mergedABI = mergeABIs([proxyContract.abi, artifact.abi], {
-      check: checkABIConflict, // TODO options for custom proxy ?
+      check: checkABIConflict,
       skipSupportsInterface: true, // TODO options for custom proxy ?
     }).filter((v) => v.type !== 'constructor');
     mergedABI.push(proxyContractConstructor); // use proxy constructor abi

--- a/types.ts
+++ b/types.ts
@@ -113,6 +113,8 @@ type ProxyOptionsBase = {
         artifact?: string | ArtifactData;
       };
   implementationName?: string;
+  checkABIConflict?: boolean;
+  checkProxyAdmin?: boolean;
 };
 
 export type ProxyOptions =


### PR DESCRIPTION
The current version does not allow to use `ERC1967Proxy` directly from OpenZepplin for UUPS proxy. It breaks on updates during proxy admin check, as UUPS does not have regular proxy admin.

This change adds the ability to override `checkABIConflict` and `checkProxyAdmin` directly through proxy params. 